### PR TITLE
Fix compilation issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "buildroot-bootlin"]
 	path = buildroot-bootlin
 	url = https://github.com/bootlin/buildroot.git
+    branch = st/2021.02
 [submodule "external/hello-rustee"]
 	path = external/hello-rustee
 	url = https://github.com/Zondax/hello-rustee

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,16 @@ IMAGES=$(MAKEFILE_DIR)/buildroot/output/images
 all:
 	@cd buildroot && make all
 
+dk2:
+	@cd buildroot-bootlin && make all
+
 git-reset:
 	@git submodule foreach --recursive git reset --hard
 	@git submodule update --init --recursive
 
 ccache-setup:
 	@cd buildroot && make CCACHE_OPTIONS="--max-size=50G --zero-stats" ccache-options
+	@cd buildroot-bootlin && make CCACHE_OPTIONS="--max-size=50G --zero-stats" ccache-options
 
 # To exit QEMU use ctrl-a + X
 start-qemu-host:
@@ -24,3 +28,4 @@ start-qemu-host:
 
 .DEFAULT:
 	@cd buildroot && make $@
+	@cd buildroot-bootlin && make $@


### PR DESCRIPTION
Not sure how to avoid it but when calling configure, for any of the supported boards, we end up making the call in both buildroot modules.
Adds a new rule:
`make dk2`
to build an image for the dk2 board.
