### PR TITLE
fix dk2_build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 MAKEFILE_DIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 export BR2_EXTERNAL = $(MAKEFILE_DIR)
-IMAGES=$(MAKEFILE_DIR)/buildroot/output/images
-
 BUILDROOT_DIR=$(MAKEFILE_DIR)/buildroot
+
 ifeq ($(BUILDROOT), st)
 	BUILDROOT_DIR=$(MAKEFILE_DIR)/buildroot-st
 endif
 
-all:
+IMAGES=$(BUILDROOT_DIR)/output/images
+
+image_dir:
+	@ln -sfT $(IMAGES) $(MAKEFILE_DIR)/images
+
+all:image_dir
 	@cd $(BUILDROOT_DIR) && make all
 
 git-reset:

--- a/images
+++ b/images
@@ -1,1 +1,0 @@
-buildroot/output/images


### PR DESCRIPTION
- Use recommended branch for dk2 builds.
- Creates images syn link at runtime. 