### PR TITLE
use custom scripts to sign dk2 images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
         submodules: 'true'
     - name: Build image
       run: |
+        pip3 install pycryptodomex
         ./tools/optee/gen_keys.sh
         ./tools/uboot/gen_keys.sh
         ./tools/dk2/generate_keys.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
     - name: Build image
       run: |
         ./tools/optee/gen_keys.sh
+        ./tools/uboot/gen_keys.sh
+        ./tools/dk2/generate_keys.sh
         make git-reset
         make dk2
 

--- a/board/zondax/stm32mp157/post-image.sh
+++ b/board/zondax/stm32mp157/post-image.sh
@@ -18,13 +18,6 @@ atf_image()
 main()
 {
 	local ATFBIN="$(atf_image)"
-    signedFileName="$(echo "${ATFBIN}" | sed 's/-mx*/-mx_Signed/g')"
-
-    if [ -f ${BINARIES_DIR}/$signedFileName ]; then
-        echo "Signed image detected. Using it"
-        mv ${BINARIES_DIR}/${ATFBIN} ${BINARIES_DIR}/${ATFBIN}".backup"
-        cp ${BINARIES_DIR}/$signedFileName ${BINARIES_DIR}/${ATFBIN} 
-    fi
 
 	if [ ! -e ${BINARIES_DIR}/${ATFBIN} ]; then
 		echo "Can not find ATF binary ${ATFBIN}"

--- a/board/zondax/stm32mp157/post_build.sh
+++ b/board/zondax/stm32mp157/post_build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# This script acts as a post processing utility
+
+BOARD_DIR=$BR2_EXTERNAL_ZONDAXTEE_PATH/board/zondax/stm32mp157/
+
+# First sign the tf_a_image
+source $BOARD_DIR/sign_tfa.sh
+
+# Sign UBOOT
+source $BOARD_DIR/sign_uboot.sh
+

--- a/board/zondax/stm32mp157/sign_tfa.sh
+++ b/board/zondax/stm32mp157/sign_tfa.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+images_dir=$BR2_EXTERNAL_ZONDAXTEE_PATH/images/
+tools_dir=$BR2_EXTERNAL_ZONDAXTEE_PATH/tools/dk2/
+
+tf_a_suffix="stm32"
+
+source $tools_dir/keys_base.sh
+
+for img_file in "${BINARIES_DIR}/"*".${tf_a_suffix}"; do
+    [ -e "$img_file" ] || continue
+    python3 $tools_dir/sign_tfa.py "$img_file" \
+        "${keysDir}/${privateKey}" "${pass}"
+    if [ $? -eq 0 ]; then
+        echo "$img_file signed"
+    else
+        echo "Signing $img_file failed"
+        exit 1
+    fi
+done
+
+

--- a/configs/zondaxtee_stm32mp157_dk2_defconfig
+++ b/configs/zondaxtee_stm32mp157_dk2_defconfig
@@ -8,7 +8,8 @@ BR2_TARGET_GENERIC_ISSUE="Welcome to Zondax TEE"
 BR2_PER_PACKAGE_DIRECTORIES=y
 BR2_ROOTFS_OVERLAY="$(BR2_EXTERNAL_ZONDAXTEE_PATH)/board/zondax/stm32mp157/dk2-overlay/  $(BR2_EXTERNAL_ZONDAXTEE_PATH)/board/zondax/common/rootfs-overlay/"
 BR2_ROOTFS_POST_IMAGE_SCRIPT="$(BR2_EXTERNAL_ZONDAXTEE_PATH)/board/zondax/stm32mp157/post-image.sh"
-BR2_ROOTFS_POST_BUILD_SCRIPT="$(BR2_EXTERNAL_ZONDAXTEE_PATH)/board/zondax/stm32mp157/sign_uboot.sh"
+# with this hook we sign tf-a and uboot
+BR2_ROOTFS_POST_BUILD_SCRIPT="$(BR2_EXTERNAL_ZONDAXTEE_PATH)/board/zondax/stm32mp157/post_build.sh"
 
 BR2_LINUX_KERNEL=y
 BR2_LINUX_KERNEL_CUSTOM_GIT=y

--- a/tools/dk2/generate_keys.sh
+++ b/tools/dk2/generate_keys.sh
@@ -5,24 +5,17 @@ script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source $script_path/keys_base.sh
 
-if ! command -v STM32MP_KeyGen_CLI &> /dev/null
-then
-    echo "STM32MP_KeyGen_CLI could not be found"
-    echo "Go to https://wiki.st.com/stm32mpu/wiki/STM32CubeProgrammer /
-
-    for further instructions on how to install it"
-    exit
-fi
-
 # Create keys directory if it doesn't exist
 if [ ! -d $keysDir ]; then
     mkdir -p $keysDir
 fi
 
 # Copy keys only if they do not exist
-if [[ ! -f $keysDir/$privateKey ]] && [[ ! -f $keysDir/$publicKey ]] && [[ ! -f $keysDir/$pkh ]]; then
-    #Generate keys with STM32MP_KeyGen_CLI
-    STM32MP_KeyGen_CLI -prvk $keysDir/$privateKey -pubk $keysDir/$publicKey -pwd $pass
+if [[ ! -f $keysDir/$privateKey ]]; then
+    openssl genpkey -algorithm ec \
+        -pkeyopt ec_paramgen_curve:prime256v1 \
+        -aes-256-cbc -pass pass:"${pass}" \
+        -out "${keysDir}/${privateKey}"
 
     if [ $? -eq 0 ]; then
         echo "Key generation successful"
@@ -34,6 +27,16 @@ if [[ ! -f $keysDir/$privateKey ]] && [[ ! -f $keysDir/$publicKey ]] && [[ ! -f 
 else
     echo "Keys already in ${keysDir} skipping key-generation"
     echo "Make a security copy of them"
+fi
+
+python3 $script_path/make_hash.py "${keysDir}/${pkh}" "${keysDir}/${privateKey}" "${pass}"
+
+if [ $? -eq 0 ]; then
+    echo "KeyHash generation successful"
+    echo "KeyHash located in ${keysDir} It is important to make a copy of those keys and save them in a safe place"
+else
+    echo "KeyHash generation failed"
+    exit 1
 fi
 
 # Generate unencrypted private key if they do not exist

--- a/tools/dk2/make_hash.py
+++ b/tools/dk2/make_hash.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import sys
+
+from Cryptodome.Hash import SHA256
+from Cryptodome.PublicKey import ECC
+from Cryptodome.Signature import DSS
+
+bin_path = sys.argv[1]
+key_path = sys.argv[2]
+key_pass = sys.argv[3]
+
+with open(key_path, "rb") as key_file:
+    key = ECC.import_key(key_file.read(), passphrase=key_pass)
+
+prime256_names = ["NIST P-256", "p256", "P-256", "prime256v1", "secp256r1"]
+if key.curve not in prime256_names:
+    raise ValueError(f"Unsupported curve: {key.curve}")
+
+bytes_x_point = key.pointQ.x.to_bytes().rjust(32, b"\0")
+bytes_y_point = key.pointQ.y.to_bytes().rjust(32, b"\0")
+
+key_hash = SHA256.new(bytes_x_point + bytes_y_point)
+
+with open(bin_path, "wb") as bin_file:
+    bin_file.write(key_hash.digest())

--- a/tools/dk2/sign_tfa.py
+++ b/tools/dk2/sign_tfa.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import sys
+import struct
+
+from Cryptodome.Hash import SHA256
+from Cryptodome.PublicKey import ECC
+from Cryptodome.Signature import DSS
+
+img_path = sys.argv[1]
+key_path = sys.argv[2]
+key_pass = sys.argv[3]
+
+with open(key_path, "rb") as key_file:
+    key = ECC.import_key(key_file.read(), passphrase=key_pass)
+
+prime256_names = ["NIST P-256", "p256", "P-256", "prime256v1", "secp256r1"]
+if key.curve not in prime256_names:
+    raise ValueError(f"Unsupported curve: {key.curve}")
+
+bytes_x_point = key.pointQ.x.to_bytes().rjust(32, b"\0")
+bytes_y_point = key.pointQ.y.to_bytes().rjust(32, b"\0")
+
+with open(img_path, "rb") as img_file:
+    data = bytearray(img_file.read())
+
+if data[0:4] != b"STM2":
+    raise ValueError("Invalid image format")
+
+data[100:104] = struct.pack("<I", 0)
+data[104:108] = struct.pack("<I", 1)
+data[108:140] = bytes_x_point
+data[140:172] = bytes_y_point
+
+img_hash = SHA256.new(data[72:])
+data[4:68] = DSS.new(key, "fips-186-3").sign(img_hash)
+
+with open(img_path, "wb") as img_file:
+    img_file.write(data)

--- a/tools/uboot/gen_keys.sh
+++ b/tools/uboot/gen_keys.sh
@@ -27,7 +27,8 @@ if [[ ! -f $keysDir/$uboot_key ]] && [[ ! -f $keysDir/$uboot_cert ]] && [[ ! -f 
         exit 1
     fi
     
-    openssl req -new -x509 -key $keysDir/$uboot_key -out $keysDir/$uboot_cert 
+    openssl req -new -x509 -key $keysDir/$uboot_key -out $keysDir/$uboot_cert \
+        -subj '/C=CH/ST=Zug/L=./CN=www.zondax.ch'
 
     if [ $? -eq 0 ]; then
         echo "Uboot cert generation successful"


### PR DESCRIPTION
This gets rid of STSigningTools used to generate keys and sign the TFA partition for dk2 builds.
the keys have to be generated manually, but the signing process is handled by buildroot, by calling the provided scripts to sign uboot and tfa after those images are built. 

<!-- ClickUpRef: 2jttwx6 -->
:link: [zboto Link](https://app.clickup.com/t/2jttwx6)